### PR TITLE
allow overrides for builtins

### DIFF
--- a/overrides/overrides.py
+++ b/overrides/overrides.py
@@ -156,7 +156,10 @@ def _get_base_class_names(frame):
 
 
 def _get_base_class(components, namespace):
-    obj = namespace[components[0]]
+    try:
+        obj = namespace[components[0]]
+    except KeyError:
+        obj = namespace["__builtins__"][components[0]]
     for component in components[1:]:
         obj = getattr(obj, component)
     return obj

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -36,6 +36,11 @@ class Sub2(test_somepackage.SomeClass,
     def some_method(self):
         pass
 
+class SubclassOfInt(int):
+
+    @overrides
+    def __str__(self):
+        return "subclass of int"
 
 class OverridesTests(unittest.TestCase):
 
@@ -64,6 +69,9 @@ class OverridesTests(unittest.TestCase):
         except AssertionError:
             pass
 
+    def test_can_override_builtin(self):
+        x = SubclassOfInt(10)
+        self.assertEqual(str(x), 'subclass of int')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The decorator doesn't work for subclasses of builtin types because they are keys in `namespace['__builtins__']`, not in `namespace`. Why would you subclass `int`? I wouldn't, but when you use generic types that's what ends up happening.

This PR contains a test case that reproduced my issue and a fix.