### PR TITLE
python 2(.7 at least) support for EnforceOverrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ target/
 # Idea
 .idea/
 overrides.iml
+
+# Pipenv
+Pipfile*

--- a/overrides/__init__.py
+++ b/overrides/__init__.py
@@ -4,6 +4,7 @@ if sys.version < '3':
     from overrides import overrides
     from final import final
     from overrides import __VERSION__
+    from enforce27 import EnforceOverrides
 else:
     from overrides.overrides import overrides
     from overrides.final import final

--- a/overrides/enforce.py
+++ b/overrides/enforce.py
@@ -1,15 +1,8 @@
 from abc import ABCMeta
 
 
-def _inherit_docstring_1(bases, name, member):
-    # Proved parent docstring if it's missing here
-    if not getattr(member, '__doc__'):
-        member.__doc__ = getattr(bases[-1], name).__doc__
-    # <https://github.com/sphinx-doc/sphinx/issues/3140>
-
-
-def _inherit_docstring_2(cls, name, member):
-    # Proved parent docstring if it's missing here
+def _inherit_docstring(cls, name, member):
+    # Provide parent docstring if it's missing here
     if not getattr(member, '__doc__'):
         for base in cls.__mro__[1:]:
             try:
@@ -26,8 +19,7 @@ class EnforceOverridesMeta(ABCMeta):
     def __new__(mcls, name, bases, namespace, **kwargs):
         cls = super().__new__(mcls, name, bases, namespace, **kwargs)
         for name, value in namespace.items():
-#            _inherit_docstring_1(bases, name, value)
-            _inherit_docstring_2(cls, name, value)
+            _inherit_docstring(cls, name, value)
 
             # Actually checking the direct parent should be enough,
             # otherwise the error would have emerged during the parent class checking

--- a/overrides/enforce.py
+++ b/overrides/enforce.py
@@ -1,10 +1,34 @@
 from abc import ABCMeta
 
 
+def _inherit_docstring_1(bases, name, member):
+    # Proved parent docstring if it's missing here
+    if not getattr(member, '__doc__'):
+        member.__doc__ = getattr(bases[-1], name).__doc__
+    # <https://github.com/sphinx-doc/sphinx/issues/3140>
+
+
+def _inherit_docstring_2(cls, name, member):
+    # Proved parent docstring if it's missing here
+    if not getattr(member, '__doc__'):
+        for base in cls.__mro__[1:]:
+            try:
+                member.__doc__ = getattr(base, name).__doc__
+                break
+            except AttributeError:
+                pass
+            except TypeError:
+                break  # this can happen e.g. for @property entries
+    # <https://github.com/sphinx-doc/sphinx/issues/3140>
+
+
 class EnforceOverridesMeta(ABCMeta):
     def __new__(mcls, name, bases, namespace, **kwargs):
         cls = super().__new__(mcls, name, bases, namespace, **kwargs)
         for name, value in namespace.items():
+#            _inherit_docstring_1(bases, name, value)
+            _inherit_docstring_2(cls, name, value)
+
             # Actually checking the direct parent should be enough,
             # otherwise the error would have emerged during the parent class checking
             if name.startswith('__'):

--- a/overrides/enforce27.py
+++ b/overrides/enforce27.py
@@ -3,7 +3,8 @@ from abc import ABCMeta
 
 class EnforceOverridesMeta(ABCMeta):
     def __new__(mcls, name, bases, namespace, **kwargs):
-        cls = super(mcls, mcls).__new__(mcls, name, bases, namespace, **kwargs)
+        cls = super(EnforceOverridesMeta, mcls).__new__(mcls, name, bases, namespace, **kwargs)
+        cls_name = name
         for name, value in namespace.items():
             # Actually checking the direct parent should be enough,
             # otherwise the error would have emerged during the parent class checking
@@ -15,10 +16,12 @@ class EnforceOverridesMeta(ABCMeta):
                 if not base_class_method:
                     continue
                 assert is_override, \
-                    'Method %s overrides but does not have @overrides decorator' % (name)
+                    '%s method %s overrides but does not have @overrides decorator' % (
+                        cls_name, name)
                 # `__finalized__` is added by `@final` decorator
                 assert not getattr(base_class_method, '__finalized__', False), \
-                    'Method %s is finalized in %s, it cannot be overridden' % (base_class_method, base)
+                    '%s method %s is finalized in %s, it cannot be overridden' % (
+                        cls_name, base_class_method, base)
         return cls
 
 class EnforceOverrides(object):

--- a/overrides/enforce27.py
+++ b/overrides/enforce27.py
@@ -1,0 +1,26 @@
+from abc import ABCMeta
+
+
+class EnforceOverridesMeta(ABCMeta):
+    def __new__(mcls, name, bases, namespace, **kwargs):
+        cls = super(mcls, mcls).__new__(mcls, name, bases, namespace, **kwargs)
+        for name, value in namespace.items():
+            # Actually checking the direct parent should be enough,
+            # otherwise the error would have emerged during the parent class checking
+            if name.startswith('__'):
+                continue
+            is_override = getattr(value, '__override__', False)
+            for base in bases:
+                base_class_method = getattr(base, name, False)
+                if not base_class_method:
+                    continue
+                assert is_override, \
+                    'Method %s overrides but does not have @overrides decorator' % (name)
+                # `__finalized__` is added by `@final` decorator
+                assert not getattr(base_class_method, '__finalized__', False), \
+                    'Method %s is finalized in %s, it cannot be overridden' % (base_class_method, base)
+        return cls
+
+class EnforceOverrides(object):
+    "Use this as the parent class for your custom classes"
+    __metaclass__ = EnforceOverridesMeta

--- a/overrides/enforce27.py
+++ b/overrides/enforce27.py
@@ -1,11 +1,27 @@
 from abc import ABCMeta
 
 
+def _inherit_docstring_2(cls, name, member):
+    # Proved parent docstring if it's missing here
+    if not getattr(member, '__doc__'):
+        for base in cls.__mro__[1:]:
+            try:
+                member.__doc__ = getattr(base, name).__doc__
+                break
+            except AttributeError:
+                pass
+            except TypeError:
+                break  # this can happen e.g. for @property entries
+    # <https://github.com/sphinx-doc/sphinx/issues/3140>
+
+
 class EnforceOverridesMeta(ABCMeta):
     def __new__(mcls, name, bases, namespace, **kwargs):
         cls = super(EnforceOverridesMeta, mcls).__new__(mcls, name, bases, namespace, **kwargs)
         cls_name = name
         for name, value in namespace.items():
+            _inherit_docstring_2(cls, name, value)
+
             # Actually checking the direct parent should be enough,
             # otherwise the error would have emerged during the parent class checking
             if name.startswith('__'):

--- a/overrides/enforce27.py
+++ b/overrides/enforce27.py
@@ -1,8 +1,8 @@
 from abc import ABCMeta
 
 
-def _inherit_docstring_2(cls, name, member):
-    # Proved parent docstring if it's missing here
+def _inherit_docstring(cls, name, member):
+    # Provide parent docstring if it's missing here
     if not getattr(member, '__doc__'):
         for base in cls.__mro__[1:]:
             try:
@@ -20,7 +20,7 @@ class EnforceOverridesMeta(ABCMeta):
         cls = super(EnforceOverridesMeta, mcls).__new__(mcls, name, bases, namespace, **kwargs)
         cls_name = name
         for name, value in namespace.items():
-            _inherit_docstring_2(cls, name, value)
+            _inherit_docstring(cls, name, value)
 
             # Actually checking the direct parent should be enough,
             # otherwise the error would have emerged during the parent class checking

--- a/overrides/enforce27.py
+++ b/overrides/enforce27.py
@@ -10,10 +10,11 @@ class EnforceOverridesMeta(ABCMeta):
             # otherwise the error would have emerged during the parent class checking
             if name.startswith('__'):
                 continue
+            value = mcls.handle_special_value(value)
             is_override = getattr(value, '__override__', False)
             for base in bases:
                 base_class_method = getattr(base, name, False)
-                if not base_class_method:
+                if not base_class_method or not callable(base_class_method):
                     continue
                 assert is_override, \
                     '%s method %s overrides but does not have @overrides decorator' % (
@@ -23,6 +24,15 @@ class EnforceOverridesMeta(ABCMeta):
                     '%s method %s is finalized in %s, it cannot be overridden' % (
                         cls_name, base_class_method, base)
         return cls
+
+    @staticmethod
+    def handle_special_value(value):
+        if isinstance(value, classmethod):
+            value = value.__get__(None, dict)
+        elif isinstance(value, property):
+            value = value.fget
+        return value
+
 
 class EnforceOverrides(object):
     "Use this as the parent class for your custom classes"

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -1,48 +1,45 @@
-import sys
+import unittest
+from overrides import overrides,final,EnforceOverrides
 
-if sys.version >= '3':
-    import unittest
-    from overrides import overrides,final,EnforceOverrides
+class Enforcing(EnforceOverrides):
 
-    class Enforcing(EnforceOverrides):
+    @final
+    def finality(self):
+        return "final"
 
-        @final
-        def finality(self):
-            return "final"
+    def nonfinal1(self):
+        return "super1"
 
-        def nonfinal1(self):
-            return "super1"
+    def nonfinal2(self):
+        return "super2"
 
-        def nonfinal2(self):
-            return "super2"
-    
-    class EnforceTests(unittest.TestCase):
+class EnforceTests(unittest.TestCase):
 
-        def test_enforcing_when_all_ok(self):
-            class Subclazz(Enforcing):
-                @overrides
-                def nonfinal1(self):
-                    return 1
-            sc = Subclazz()
-            self.assertEqual(sc.finality(), "final")
-            self.assertEqual(sc.nonfinal1(), 1)
-            self.assertEqual(sc.nonfinal2(), "super2")
-    
-        def tests_enforcing_when_finality_broken(self):
-            try:
-                class BrokesFinality(Enforcing):
-                    def finality(self):
-                        return "NEVER HERE"
-                raise RuntimeError('Should not go here')
-            except AssertionError:
-                pass
-    
-        def test_enforcing_when_none_explicit_override(self):
-            try:
-                class Overrider(Enforcing):
-                    def nonfinal2(self):
-                        return "NEVER HERE EITHER"
-                raise RuntimeError('Should not go here')
-            except AssertionError:
-                pass
+    def test_enforcing_when_all_ok(self):
+        class Subclazz(Enforcing):
+            @overrides
+            def nonfinal1(self):
+                return 1
+        sc = Subclazz()
+        self.assertEqual(sc.finality(), "final")
+        self.assertEqual(sc.nonfinal1(), 1)
+        self.assertEqual(sc.nonfinal2(), "super2")
+
+    def tests_enforcing_when_finality_broken(self):
+        try:
+            class BrokesFinality(Enforcing):
+                def finality(self):
+                    return "NEVER HERE"
+            raise RuntimeError('Should not go here')
+        except AssertionError:
+            pass
+
+    def test_enforcing_when_none_explicit_override(self):
+        try:
+            class Overrider(Enforcing):
+                def nonfinal2(self):
+                    return "NEVER HERE EITHER"
+            raise RuntimeError('Should not go here')
+        except AssertionError:
+            pass
 

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -2,6 +2,7 @@ import unittest
 from overrides import overrides,final,EnforceOverrides
 
 class Enforcing(EnforceOverrides):
+    "BASE class docstring"
 
     classVariableIsOk = "OK?"
 
@@ -10,9 +11,11 @@ class Enforcing(EnforceOverrides):
         return "final"
 
     def nonfinal1(self):
+        "BASE nonfinal1 docstring"
         return "super1"
 
     def nonfinal2(self):
+        "BASE nonfinal2 docstring"
         return "super2"
 
     @property
@@ -36,6 +39,22 @@ class EnforceTests(unittest.TestCase):
         self.assertEqual(sc.nonfinal1(), 1)
         self.assertEqual(sc.nonfinal2(), "super2")
         self.assertEqual(sc.classVariableIsOk, "OK!")
+
+
+    def test_docstring_inheritance(self):
+        class Subclazz(Enforcing):
+            @overrides
+            def nonfinal1(self):
+                "SUB nonfinal1 docstring"
+                return 1
+            @overrides
+            def nonfinal2(self):
+                return 1
+        sc = Subclazz()
+#        self.assertEqual(sc.__doc__, "BASE class docstring")  # does not (yet?) work for class doc
+        self.assertEqual(sc.nonfinal1.__doc__, "SUB nonfinal1 docstring")
+        self.assertEqual(sc.nonfinal2.__doc__, "BASE nonfinal2 docstring")
+
 
     def tests_enforcing_when_finality_broken(self):
         try:


### PR DESCRIPTION
duplicate `enforce.py` file in python 2(.7) syntax: `super()` with two arguments, and `__metaclass__` attribute (instead of class def kwarg)

also modified `test_enforce.py` to always run (not just for python version 3+)