### PR TITLE
Fix enforcemnt for classmethod 

### DIFF
--- a/overrides/enforce.py
+++ b/overrides/enforce.py
@@ -9,6 +9,8 @@ class EnforceOverridesMeta(ABCMeta):
             # otherwise the error would have emerged during the parent class checking
             if name.startswith('__'):
                 continue
+            if isinstance(value, classmethod):
+                value = value.__get__(None, dict)
             is_override = getattr(value, '__override__', False)
             for base in bases:
                 base_class_method = getattr(base, name, False)

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -15,6 +15,10 @@ if sys.version >= '3':
 
         def nonfinal2(self):
             return "super2"
+
+        @classmethod
+        def nonfinal_classmethod(cls):
+            return "super_classmethod"
     
     class EnforceTests(unittest.TestCase):
 
@@ -46,3 +50,14 @@ if sys.version >= '3':
             except AssertionError:
                 pass
 
+        def test_enforcing_when_classmethod_overriden(self):
+            subclass_return_str = "suclass"
+
+            class ClassMethodOverrider(Enforcing):
+                @classmethod
+                @overrides
+                def nonfinal_classmethod(cls):
+                    return subclass_return_str
+
+            self.assertEqual(ClassMethodOverrider.nonfinal_classmethod(),
+                             subclass_return_str)

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -51,13 +51,11 @@ if sys.version >= '3':
                 pass
 
         def test_enforcing_when_classmethod_overriden(self):
-            return_str = "subclass_classmethod"
-
             class ClassMethodOverrider(Enforcing):
                 @classmethod
                 @overrides
                 def nonfinal_classmethod(cls):
-                    return return_str
+                    return "subclass_classmethod"
 
-            self.assertEqual(ClassMethodOverrider.nonfinal_classmethod(),
-                             return_str)
+            self.assertNotEqual(ClassMethodOverrider.nonfinal_classmethod(),
+                                Enforcing.nonfinal_classmethod())

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -51,13 +51,13 @@ if sys.version >= '3':
                 pass
 
         def test_enforcing_when_classmethod_overriden(self):
-            subclass_return_str = "suclass"
+            return_str = "subclass_classmethod"
 
             class ClassMethodOverrider(Enforcing):
                 @classmethod
                 @overrides
                 def nonfinal_classmethod(cls):
-                    return subclass_return_str
+                    return return_str
 
             self.assertEqual(ClassMethodOverrider.nonfinal_classmethod(),
-                             subclass_return_str)
+                             return_str)


### PR DESCRIPTION
https://github.com/mkorpela/overrides/issues/30

In enforcement.py, `is_override` is tested using `getattr`.
When given a classmethod, attributes can only be accessed once getting the method. 