### PR TITLE
Add inline type annotations

### DIFF
--- a/overrides/final.py
+++ b/overrides/final.py
@@ -13,11 +13,15 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
+from typing import Any, Callable, TypeVar
 
 __VERSION__ = '0.1'
 
 
-def final(method):
+_WrappedMethod = TypeVar('WrappedMethod', bound=Callable[..., Any])
+
+
+def final(method: _WrappedMethod) -> _WrappedMethod:
     """Decorator to indicate that the decorated method is finalized and cannot be overridden.
     The decorator code is executed while loading class. Using this method
     should have minimal runtime performance implications.

--- a/overrides/overrides.py
+++ b/overrides/overrides.py
@@ -16,7 +16,7 @@
 
 import sys
 import dis
-from typing import List, Tuple
+from typing import Any, Callable, List, Tuple, TypeVar
 __VERSION__ = '2.8.0'
 
 if sys.version < '3':
@@ -28,7 +28,10 @@ else:
     long = int
 
 
-def overrides(method):
+_WrappedMethod = TypeVar('WrappedMethod', bound=Callable[..., Any])
+
+
+def overrides(method: _WrappedMethod) -> _WrappedMethod:
     """Decorator to indicate that the decorated method overrides a method in
     superclass.
     The decorator code is executed while loading class. Using this method

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(name='overrides',
       classifiers=[
           'Intended Audience :: Developers',
           'Natural Language :: English',
-          'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7'
           ]

--- a/stubs/__init__.pyi
+++ b/stubs/__init__.pyi
@@ -1,6 +1,0 @@
-from typing import Any, Callable, TypeVar
-
-_FuncT = TypeVar('_FuncT', bound=Callable[..., Any])
-
-def final(method: _FuncT) -> _FuncT: ...
-def overrides(method: _FuncT) -> _FuncT: ...


### PR DESCRIPTION
Hey, I would like to provide a clean solution for #37 by adding type hints directly to the relevant functions. Please note that python's typing module was introduced in python 3.5 and a previous commit in this repository had already made the library incompatible with earlier python versions, including 2.7. So I took the liberty of also removing the claim to support python 2.7.