### PR TITLE
[DRAFT] add init type stub for EnforceOverrides for mypy strict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # C extensions
 *.so
+.DS_Store
 
 # Distribution / packaging
 .Python

--- a/overrides/__init__.py
+++ b/overrides/__init__.py
@@ -1,4 +1,3 @@
-from overrides.overrides import overrides
-from overrides.final import final
-from overrides.overrides import __VERSION__
 from overrides.enforce import EnforceOverrides
+from overrides.final import final
+from overrides.overrides import __VERSION__, overrides

--- a/overrides/enforce.py
+++ b/overrides/enforce.py
@@ -17,12 +17,11 @@ class EnforceOverridesMeta(ABCMeta):
                     continue
                 assert (
                     is_override
-                ), "Method %s overrides but does not have @overrides decorator" % (name)
+                ), f"Method {name} overrides but does not have @overrides decorator"
                 # `__finalized__` is added by `@final` decorator
-                assert not getattr(base_class_method, "__finalized__", False), (
-                    "Method %s is finalized in %s, it cannot be overridden"
-                    % (base_class_method, base)
-                )
+                assert not getattr(
+                    base_class_method, "__finalized__", False
+                ), f"Method {base_class_method} is finalized in {base}, it cannot be overridden"
         return cls
 
     @staticmethod

--- a/overrides/enforce.py
+++ b/overrides/enforce.py
@@ -35,5 +35,7 @@ class EnforceOverridesMeta(ABCMeta):
 
 
 class EnforceOverrides(metaclass=EnforceOverridesMeta):
-    "Use this as the parent class for your custom classes"
-    pass
+    """ Use this as the parent class for your custom classes """
+
+    def __init__(self) -> None:
+        super().__init__()

--- a/overrides/final.py
+++ b/overrides/final.py
@@ -13,8 +13,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 #
-from typing import TypeVar
 from types import FunctionType
+from typing import TypeVar
 
 __VERSION__ = "0.1"
 

--- a/overrides/overrides.py
+++ b/overrides/overrides.py
@@ -14,10 +14,10 @@
 #  limitations under the License.
 #
 
-import sys
 import dis
-from typing import List, Tuple, TypeVar
+import sys
 from types import FunctionType
+from typing import List, Tuple, TypeVar
 
 __VERSION__ = "3.1.0"
 
@@ -60,11 +60,11 @@ def overrides(method: _WrappedMethod) -> _WrappedMethod:
             if hasattr(super_method, "__finalized__"):
                 finalized = getattr(super_method, "__finalized__")
                 if finalized:
-                    raise AssertionError('Method "%s" is finalized' % method.__name__)
+                    raise AssertionError(f'Method "method.__name__" is finalized')
             if not method.__doc__:
                 method.__doc__ = super_method.__doc__
             return method
-    raise AssertionError('No super class method found for "%s"' % method.__name__)
+    raise AssertionError(f'No super class method found for "{method.__name__}"')
 
 
 def _get_base_classes(frame, namespace):

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,38 @@
 #!/usr/bin/env python
 
 from distutils.core import setup
-from setuptools import find_packages # type: ignore
-from os.path import abspath, join, dirname
+from os.path import abspath, dirname, join
 
-name = 'Mikko Korpela'
+from setuptools import find_packages  # type: ignore
+
+name = "Mikko Korpela"
 # I might be just a little bit too much afraid of those bots..
-address = name.lower().replace(' ', '.')+chr(64)+'gmail.com'
+address = name.lower().replace(" ", ".") + chr(64) + "gmail.com"
 
-desc = 'A decorator to automatically detect mismatch when overriding a method.'
+desc = "A decorator to automatically detect mismatch when overriding a method."
 
 CURDIR = dirname(abspath(__file__))
 
-with open(join(CURDIR, 'README.rst')) as f:
+with open(join(CURDIR, "README.rst")) as f:
     LONG_DESCRIPTION = f.read()
 
-setup(name='overrides',
-      version='3.1.0',
-      description=desc,
-      long_description=LONG_DESCRIPTION,
-      author=name,
-      author_email=address,
-      url='https://github.com/mkorpela/overrides',
-      packages=find_packages(),
-      install_requires=['typing;python_version<"3.5"'],
-      license='Apache License, Version 2.0',
-      keywords=['override', 'inheritence', 'OOP'],
-      classifiers=[
-          'Intended Audience :: Developers',
-          'Natural Language :: English',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
-          'Programming Language :: Python :: 3.8'
-          ]
-      )
+setup(
+    name="overrides",
+    version="3.1.0",
+    description=desc,
+    long_description=LONG_DESCRIPTION,
+    author=name,
+    author_email=address,
+    url="https://github.com/mkorpela/overrides",
+    packages=find_packages(),
+    install_requires=['typing;python_version<"3.5"'],
+    license="Apache License, Version 2.0",
+    keywords=["override", "inheritence", "OOP"],
+    classifiers=[
+        "Intended Audience :: Developers",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+    ],
+)

--- a/tests/test_decorator_params.py
+++ b/tests/test_decorator_params.py
@@ -1,4 +1,5 @@
 from typing import Callable, Type
+
 from overrides import overrides
 
 
@@ -10,6 +11,7 @@ class SuperClass:
 def my_decorator(name: str) -> Callable:
     def func(cls: Type) -> Type:
         return cls
+
     return func
 
 

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -1,7 +1,7 @@
+import unittest
 from typing import Dict
 
-import unittest
-from overrides import overrides,final,EnforceOverrides
+from overrides import EnforceOverrides, final, overrides
 
 
 class Enforcing(EnforceOverrides):
@@ -48,19 +48,23 @@ class EnforceTests(unittest.TestCase):
 
     def tests_enforcing_when_finality_broken(self):
         try:
+
             class BrokesFinality(Enforcing):
                 def finality(self):
                     return "NEVER HERE"
-            raise RuntimeError('Should not go here')
+
+            raise RuntimeError("Should not go here")
         except AssertionError:
             pass
 
     def test_enforcing_when_none_explicit_override(self):
         try:
+
             class Overrider(Enforcing):
                 def nonfinal2(self):
                     return "NEVER HERE EITHER"
-            raise RuntimeError('Should not go here')
+
+            raise RuntimeError("Should not go here")
         except AssertionError:
             pass
 
@@ -71,8 +75,7 @@ class EnforceTests(unittest.TestCase):
             def nonfinal_property(self):
                 return "subclass_property"
 
-        self.assertNotEqual(PropertyOverrider.nonfinal_property,
-                            Enforcing.nonfinal_property)
+        self.assertNotEqual(PropertyOverrider.nonfinal_property, Enforcing.nonfinal_property)
 
     def test_enforcing_when_staticmethod_overriden(self):
         class StaticMethodOverrider(Enforcing):
@@ -82,8 +85,7 @@ class EnforceTests(unittest.TestCase):
                 return "subclass_staticmethod"
 
         self.assertNotEqual(
-            StaticMethodOverrider.nonfinal_staticmethod(),
-            Enforcing.nonfinal_staticmethod(),
+            StaticMethodOverrider.nonfinal_staticmethod(), Enforcing.nonfinal_staticmethod(),
         )
 
     def test_enforcing_when_classmethod_overriden(self):
@@ -93,5 +95,6 @@ class EnforceTests(unittest.TestCase):
             def nonfinal_classmethod(cls):
                 return "subclass_classmethod"
 
-        self.assertNotEqual(ClassMethodOverrider.nonfinal_classmethod(),
-                            Enforcing.nonfinal_classmethod())
+        self.assertNotEqual(
+            ClassMethodOverrider.nonfinal_classmethod(), Enforcing.nonfinal_classmethod()
+        )

--- a/tests/test_final.py
+++ b/tests/test_final.py
@@ -1,13 +1,13 @@
 import unittest
-from overrides import overrides,final
+
 import test_somefinalpackage
+from overrides import final, overrides
 
 
 class SuperClass(object):
-
     def some_method(self):
         """Super Class Docs"""
-        return 'super'
+        return "super"
 
     @final
     def some_finalized_method(self):
@@ -15,10 +15,9 @@ class SuperClass(object):
 
 
 class SubClass(SuperClass):
-
     @overrides
     def some_method(self):
-        return 'sub'
+        return "sub"
 
     @final
     def another_finalized(self):
@@ -26,10 +25,9 @@ class SubClass(SuperClass):
 
 
 class Sub2(test_somefinalpackage.SomeClass, SuperClass):
-
     @overrides
     def somewhat_fun_method(self):
-        return 'foo'
+        return "foo"
 
     @overrides
     def some_method(self):
@@ -37,101 +35,115 @@ class Sub2(test_somefinalpackage.SomeClass, SuperClass):
 
 
 class FinalTests(unittest.TestCase):
-
     def test_final_passes_simple(self):
         sub = SubClass()
-        self.assertEqual(sub.some_method(), 'sub')
-        self.assertEqual(sub.some_method.__doc__, 'Super Class Docs')
-        self.assertEqual(sub.some_finalized_method(), 'super_final')
+        self.assertEqual(sub.some_method(), "sub")
+        self.assertEqual(sub.some_method.__doc__, "Super Class Docs")
+        self.assertEqual(sub.some_finalized_method(), "super_final")
 
     def test_final_passes_for_superclass_in_another_package(self):
         sub2 = Sub2()
-        self.assertEqual(sub2.somewhat_fun_method(), 'foo')
-        self.assertEqual(sub2.somewhat_fun_method.__doc__, 'LULZ')
-        self.assertEqual(sub2.some_finalized_method(), 'super_final')
-        self.assertEqual(sub2.somewhat_finalized_method(), 'some_final')
+        self.assertEqual(sub2.somewhat_fun_method(), "foo")
+        self.assertEqual(sub2.somewhat_fun_method.__doc__, "LULZ")
+        self.assertEqual(sub2.some_finalized_method(), "super_final")
+        self.assertEqual(sub2.somewhat_finalized_method(), "some_final")
 
     def test_final_fails_simple(self):
         try:
+
             class SubClassFail(SuperClass):
                 @overrides
                 def some_method(self):
-                    return 'subfail'
+                    return "subfail"
+
                 @overrides
                 def some_finalized_method(self):
                     pass
-            raise RuntimeError('Should not go here')
+
+            raise RuntimeError("Should not go here")
         except AssertionError:
             pass
 
     def test_final_fails_another_package(self):
         try:
+
             class Sub2Fail(test_somefinalpackage.SomeClass, SuperClass):
                 @overrides
                 def somewhat_fun_method(self):
-                    return 'foo'
+                    return "foo"
+
                 @overrides
                 def some_method(self):
                     pass
+
                 @overrides
                 def some_finalized_method(self):
                     pass
 
-            raise RuntimeError('Should not go here')
+            raise RuntimeError("Should not go here")
         except AssertionError:
             pass
 
     def test_final_fails_deep(self):
         try:
+
             class Sub3Fail(test_somefinalpackage.SomeClass, SubClass):
                 @overrides
                 def somewhat_fun_method(self):
-                    return 'foo'
+                    return "foo"
+
                 @overrides
                 def some_method(self):
                     pass
+
                 @overrides
                 def some_finalized_method(self):
                     pass
 
-            raise RuntimeError('Should not go here')
+            raise RuntimeError("Should not go here")
         except AssertionError:
             pass
 
     def test_final_fails_in_middle(self):
         try:
+
             class Sub4Fail(test_somefinalpackage.SomeClass, SubClass):
                 @overrides
                 def somewhat_fun_method(self):
-                    return 'foo'
+                    return "foo"
+
                 @overrides
                 def some_method(self):
                     pass
+
                 @overrides
                 def another_finalized(self):
                     pass
 
-            raise RuntimeError('Should not go here')
+            raise RuntimeError("Should not go here")
         except AssertionError:
             pass
 
     def test_final_fails_from_another_package(self):
         try:
+
             class Sub5Fail(test_somefinalpackage.SomeClass, SubClass):
                 @overrides
                 def somewhat_fun_method(self):
-                    return 'foo'
+                    return "foo"
+
                 @overrides
                 def some_method(self):
                     pass
+
                 @overrides
                 def some_finalized_method(self):
                     pass
 
-            raise RuntimeError('Should not go here')
+            raise RuntimeError("Should not go here")
         except AssertionError:
             pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,9 +1,8 @@
 import unittest
-from overrides import overrides
-import test_somepackage
-
-
 from typing import Generic, TypeVar
+
+import test_somepackage
+from overrides import overrides
 
 TObject = TypeVar("TObject", bound="Foo")
 
@@ -15,89 +14,83 @@ class SubClassOfGeneric(Generic[TObject]):
 
 
 class SubSubClassOfGeneric(SubClassOfGeneric["SubSubClassOfGeneric"]):
-
     @overrides
     def some_method(self):
         return 17
 
 
 class SuperClass(object):
-
     def some_method(self):
         """Super Class Docs"""
-        return 'super'
+        return "super"
 
 
 class SubClass(SuperClass):
-
     @overrides
     def some_method(self):
-        return 'sub'
+        return "sub"
 
 
 class Subber(SuperClass):
-
     @overrides
     def some_method(self):
         """Subber"""
         return 1
 
 
-class Sub2(test_somepackage.SomeClass,
-           SuperClass):
-
+class Sub2(test_somepackage.SomeClass, SuperClass):
     @overrides
     def somewhat_fun_method(self):
-        return 'foo'
+        return "foo"
 
     @overrides
     def some_method(self):
         pass
 
-class SubclassOfInt(int):
 
+class SubclassOfInt(int):
     @overrides
     def __str__(self):
         return "subclass of int"
 
 
 class OverridesTests(unittest.TestCase):
-
     def test_overrides_passes_for_same_package_superclass(self):
         sub = SubClass()
-        self.assertEqual(sub.some_method(), 'sub')
-        self.assertEqual(sub.some_method.__doc__, 'Super Class Docs')
+        self.assertEqual(sub.some_method(), "sub")
+        self.assertEqual(sub.some_method.__doc__, "Super Class Docs")
 
     def test_overrides_does_not_override_method_doc(self):
         sub = Subber()
         self.assertEqual(sub.some_method(), 1)
-        self.assertEqual(sub.some_method.__doc__, 'Subber')
+        self.assertEqual(sub.some_method.__doc__, "Subber")
 
     def test_overrides_passes_for_superclass_in_another_package(self):
         sub2 = Sub2()
-        self.assertEqual(sub2.somewhat_fun_method(), 'foo')
-        self.assertEqual(sub2.somewhat_fun_method.__doc__, 'LULZ')
+        self.assertEqual(sub2.somewhat_fun_method(), "foo")
+        self.assertEqual(sub2.somewhat_fun_method.__doc__, "LULZ")
 
     def test_assertion_error_is_thrown_when_method_not_in_superclass(self):
         try:
+
             class ShouldFail(SuperClass):
                 @overrides
                 def somo_method(self):
                     pass
-            raise RuntimeError('Should not go here')
+
+            raise RuntimeError("Should not go here")
         except AssertionError:
             pass
 
     def test_can_override_builtin(self):
         x = SubclassOfInt(10)
-        self.assertEqual(str(x), 'subclass of int')
-
+        self.assertEqual(str(x), "subclass of int")
 
     def test_overrides_method_from_generic_subclass(self):
         genericsub = SubSubClassOfGeneric()
         self.assertEqual(genericsub.some_method(), 17)
-        self.assertEqual(genericsub.some_method.__doc__, 'Generic sub class.')
+        self.assertEqual(genericsub.some_method.__doc__, "Generic sub class.")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_somefinalpackage.py
+++ b/tests/test_somefinalpackage.py
@@ -2,10 +2,9 @@ from overrides import final
 
 
 class SomeClass(object):
-
     def somewhat_fun_method(self):
         """LULZ"""
-        return 'LOL'
+        return "LOL"
 
     @final
     def somewhat_finalized_method(self):

--- a/tests/test_somepackage.py
+++ b/tests/test_somepackage.py
@@ -1,5 +1,4 @@
 class SomeClass(object):
-
     def somewhat_fun_method(self):
         """LULZ"""
-        return 'LOL'
+        return "LOL"


### PR DESCRIPTION
The first commit fixes the problem, but repeating the original issue for clarity:

When I use mypy --strict, I get:
```
error: Class cannot subclass 'EnforceOverrides' (has type 'Any')
```

This error occurs because mypy --strict contains the --disallow-subclassing-any flag, which prevents subclasses that return Any from being subclassed with more specific type annotations, e.g.
```
class Player(EnforceOverrides):
    def __init__(self) -> None:
          pass
```

Since __init__ must return None in mypy as well, this change handles all valid use cases.


The second commit is just some minor cleanup using black + isort, as well as using f-strings instead.