### PR TITLE
Support for signature validation

### DIFF
--- a/overrides/enforce.py
+++ b/overrides/enforce.py
@@ -45,8 +45,8 @@ def ensure_compatible(
             and not (x_param.kind == Parameter.KEYWORD_ONLY and y_var_kwargs):
             raise TypeError(f"`{name}` is not present.")
         elif name in y_sig.parameters \
-            and not (x_param.kind == Parameter.VAR_POSITIONAL) \
-            and not (x_param.kind == Parameter.VAR_KEYWORD):
+            and x_param.kind != Parameter.VAR_POSITIONAL \
+            and x_param.kind != Parameter.VAR_KEYWORD:
             y_index = list(y_sig.parameters.keys()).index(name)
             y_param = y_sig.parameters[name]
             
@@ -54,7 +54,8 @@ def ensure_compatible(
                 and not (x_param.kind == Parameter.POSITIONAL_ONLY and y_param.kind == Parameter.POSITIONAL_OR_KEYWORD) \
                 and not (x_param.kind == Parameter.KEYWORD_ONLY and y_param.kind == Parameter.POSITIONAL_OR_KEYWORD):
                 raise TypeError(f"`{name}` is not `{x_param.kind.description}`")
-            elif x_param.kind != Parameter.KEYWORD_ONLY and x_index != y_index:
+            elif x_index != y_index \
+                and x_param.kind != Parameter.KEYWORD_ONLY:
                 raise TypeError(f"`{name}` is not parameter `{x_index}`")
             elif x_param.annotation != Parameter.empty \
                 and y_param.annotation != Parameter.empty \
@@ -68,8 +69,8 @@ def ensure_compatible(
     for name, y_param in y_sig.parameters.items():
         if name not in x_sig.parameters \
             and y_param.default == Parameter.empty \
-            and not (y_param.kind == Parameter.VAR_POSITIONAL) \
-            and not (y_param.kind == Parameter.VAR_KEYWORD) \
+            and y_param.kind != Parameter.VAR_POSITIONAL \
+            and y_param.kind != Parameter.VAR_KEYWORD \
             and not (y_param.kind == Parameter.KEYWORD_ONLY and x_var_kwargs) \
             and not (y_param.kind == Parameter.POSITIONAL_ONLY and x_var_args) \
             and not (y_param.kind == Parameter.POSITIONAL_OR_KEYWORD and x_var_args):

--- a/overrides/enforce.py
+++ b/overrides/enforce.py
@@ -1,23 +1,24 @@
 from abc import ABCMeta
 import inspect
+from inspect import Parameter, Signature
 from typing import Callable
 
 import typing_utils
 
 
-def is_compatible(
+def ensure_compatible(
     x: Callable,
     y: Callable,
 ) -> None:
-    """Verify that the signature of `y` is compatible with the signature of `x`.
+    """Ensure that the signature of `y` is compatible with the signature of `x`.
 
-    Ensures that any call to `x` will work on `y` by checking the following criteria:
+    Guarantees that any call to `x` will work on `y` by checking the following criteria:
 
     1. The return type of `y` is a subtype of the return type of `x`.
-    2. All parameters of `x` are present in `y`.
+    2. All parameters of `x` are present in `y`, unless `y` declares `*args` or `**kwargs`.
     3. All positional parameters of `x` appear in the same order in `y`.
     4. All parameters of `x` are a subtype of the corresponding parameters of `y`.
-    5. All parameters of `y` are present in `x`, unless `x` has a `*args` or `**kwargs` parameter.
+    5. All required parameters of `y` are present in `x`, unless `x` declares `*args` or `**kwargs`.
 
     :param x: Function to check compatibility with.
     :param y: Function to check compatibility of.
@@ -26,43 +27,52 @@ def is_compatible(
     y_sig = inspect.signature(y)
 
     # Verify that the return type of `y` is a subtype of `x`.
-    if x_sig.return_annotation != inspect.Signature.empty \
-        and y_sig.return_annotation != inspect.Signature.empty \
+    if x_sig.return_annotation != Signature.empty \
+        and y_sig.return_annotation != Signature.empty \
         and not typing_utils.issubtype(y_sig.return_annotation, x_sig.return_annotation):
         raise TypeError(f"`{y_sig.return_annotation}` is not a `{x_sig.return_annotation}`.")
 
     # Verify that all parameters in `x` are specified in `y` and that their types are compatible.
-    x_var_args = False
-    x_var_kwargs = False
+    y_var_args = any(p.kind == Parameter.VAR_POSITIONAL for p in y_sig.parameters.values())
+    y_var_kwargs = any(p.kind == Parameter.VAR_KEYWORD for p in y_sig.parameters.values())
 
     for x_index, (name, x_param) in enumerate(x_sig.parameters.items()):
-        if x_param.kind == inspect.Parameter.VAR_POSITIONAL:
-            x_var_args = True
-        elif x_param.kind == inspect.Parameter.VAR_KEYWORD:
-            x_var_kwargs = True
-        elif name not in y_sig.parameters:
+        if name not in y_sig.parameters \
+            and not (x_param.kind == Parameter.VAR_POSITIONAL and not y_var_args) \
+            and not (x_param.kind == Parameter.VAR_KEYWORD and not y_var_kwargs) \
+            and not (x_param.kind == Parameter.POSITIONAL_ONLY and y_var_args) \
+            and not (x_param.kind == Parameter.POSITIONAL_OR_KEYWORD and y_var_args and y_var_kwargs) \
+            and not (x_param.kind == Parameter.KEYWORD_ONLY and y_var_kwargs):
             raise TypeError(f"`{name}` is not present.")
-        else:
+        elif name in y_sig.parameters \
+            and not (x_param.kind == Parameter.VAR_POSITIONAL) \
+            and not (x_param.kind == Parameter.VAR_KEYWORD):
             y_index = list(y_sig.parameters.keys()).index(name)
             y_param = y_sig.parameters[name]
             
-            if x_param.kind != y_param.kind:
+            if x_param.kind != y_param.kind \
+                and not (x_param.kind == Parameter.POSITIONAL_ONLY and y_param.kind == Parameter.POSITIONAL_OR_KEYWORD) \
+                and not (x_param.kind == Parameter.KEYWORD_ONLY and y_param.kind == Parameter.POSITIONAL_OR_KEYWORD):
                 raise TypeError(f"`{name}` is not `{x_param.kind.description}`")
-            elif x_param.kind != inspect.Parameter.KEYWORD_ONLY and x_index != y_index:
+            elif x_param.kind != Parameter.KEYWORD_ONLY and x_index != y_index:
                 raise TypeError(f"`{name}` is not parameter `{x_index}`")
-            elif x_param.annotation != inspect.Parameter.empty \
-                and y_param.annotation != inspect.Parameter.empty \
+            elif x_param.annotation != Parameter.empty \
+                and y_param.annotation != Parameter.empty \
                 and not typing_utils.issubtype(x_param.annotation, y_param.annotation):
                 raise TypeError(f"`{name} must be a supertype of `{x_param.annotation}`")
 
     # Verify that no parameters are specified in `y` that are not specified in `x`.
+    x_var_args = any(p.kind == Parameter.VAR_POSITIONAL for p in x_sig.parameters.values())
+    x_var_kwargs = any(p.kind == Parameter.VAR_KEYWORD for p in x_sig.parameters.values())
+    
     for name, y_param in y_sig.parameters.items():
         if name not in x_sig.parameters \
-            and not (y_param.kind == inspect.Parameter.KEYWORD_ONLY and x_var_kwargs) \
-            and not (y_param.kind == inspect.Parameter.VAR_KEYWORD and x_var_kwargs) \
-            and not (y_param.kind == inspect.Parameter.VAR_POSITIONAL and x_var_args) \
-            and not (y_param.kind == inspect.Parameter.POSITIONAL_ONLY and x_var_args) \
-            and not (y_param.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD and x_var_args):
+            and y_param.default == Parameter.empty \
+            and not (y_param.kind == Parameter.VAR_POSITIONAL) \
+            and not (y_param.kind == Parameter.VAR_KEYWORD) \
+            and not (y_param.kind == Parameter.KEYWORD_ONLY and x_var_kwargs) \
+            and not (y_param.kind == Parameter.POSITIONAL_ONLY and x_var_args) \
+            and not (y_param.kind == Parameter.POSITIONAL_OR_KEYWORD and x_var_args):
             raise TypeError(f"`{name}` is not a valid parameter.")
 
 
@@ -88,7 +98,7 @@ class EnforceOverridesMeta(ABCMeta):
                     "Method %s is finalized in %s, it cannot be overridden"
                     % (base_class_method, base)
                 )
-                is_compatible(base_class_method, value)
+                ensure_compatible(base_class_method, value)
         return cls
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name='overrides',
       author_email=address,
       url='https://github.com/mkorpela/overrides',
       packages=find_packages(),
-      install_requires=['typing;python_version<"3.5"'],
+      install_requires=['typing;python_version<"3.5"', 'typing-utils>=0.0.3'],
       license='Apache License, Version 2.0',
       keywords=['override', 'inheritence', 'OOP'],
       classifiers=[

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 import unittest
 from overrides import overrides, final, EnforceOverrides
-from overrides.enforce import is_compatible
+from overrides.enforce import ensure_compatible
 
 
 class Enforcing(EnforceOverrides):
@@ -104,61 +104,62 @@ class EnforceTests(unittest.TestCase):
         self.assertNotEqual(ClassMethodOverrider.nonfinal_classmethod(),
                             Enforcing.nonfinal_classmethod())
 
-    def test_is_compatible_when_compatible(self):
-        def foo(x, /, y: str, *args, z: int, **kwargs) -> object:
+    def test_ensure_compatible_when_compatible(self):
+        def sup(a, /, b: str, c: int, *, d, e, **kwargs) -> object:
             pass
 
-        def bar(x, /, y: object, a: float, *, b: bytes, z: int, **kwargs) -> str:
+        def sub(a, b: object, c, d, f: str = "foo", *args, g: str = "bar", e, **kwargs) -> str:
             pass
 
-        is_compatible(foo, bar)
+        ensure_compatible(sup, sub)
+        
 
-    def test_is_compatible_when_return_types_are_incompatible(self):
-        def foo(x) -> int:
+    def test_ensure_compatible_when_return_types_are_incompatible(self):
+        def sup(x) -> int:
             pass
 
-        def bar(x) -> str:
+        def sub(x) -> str:
             pass
 
         with self.assertRaises(TypeError):
-            is_compatible(foo, bar)
+            ensure_compatible(sup, sub)
     
-    def test_is_compatible_when_parameter_positions_are_incompatible(self):
-        def foo(x, y):
+    def test_ensure_compatible_when_parameter_positions_are_incompatible(self):
+        def sup(x, y):
             pass
 
-        def bar(y, x):
+        def sub(y, x):
             pass
 
         with self.assertRaises(TypeError):
-            is_compatible(foo, bar)
+            ensure_compatible(sup, sub)
     
-    def test_is_compatible_when_parameter_types_are_incompatible(self):
-        def foo(x: object):
+    def test_ensure_compatible_when_parameter_types_are_incompatible(self):
+        def sup(x: object):
             pass
 
-        def bar(y: str):
-            pass
-
-        with self.assertRaises(TypeError):
-            is_compatible(foo, bar)
-
-    def test_is_compatible_when_parameter_kinds_are_incompatible(self):
-        def foo(x, *, y):
-            pass
-
-        def bar(x, y):
+        def sub(y: str):
             pass
 
         with self.assertRaises(TypeError):
-            is_compatible(foo, bar)
+            ensure_compatible(sup, sub)
 
-    def test_is_compatible_when_parameter_lists_are_incompatible(self):
-        def foo(x):
+    def test_ensure_compatible_when_parameter_kinds_are_incompatible(self):
+        def sup(x, /, y):
             pass
 
-        def bar(x, y):
+        def sub(x, *, y):
             pass
 
         with self.assertRaises(TypeError):
-            is_compatible(foo, bar)
+            ensure_compatible(sup, sub)
+
+    def test_ensure_compatible_when_parameter_lists_are_incompatible(self):
+        def sup(x):
+            pass
+
+        def sub(x, y):
+            pass
+
+        with self.assertRaises(TypeError):
+            ensure_compatible(sup, sub)

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -145,10 +145,10 @@ class EnforceTests(unittest.TestCase):
             ensure_compatible(sup, sub)
 
     def test_ensure_compatible_when_parameter_kinds_are_incompatible(self):
-        def sup(x, /, y):
+        def sup(x):
             pass
 
-        def sub(x, *, y):
+        def sub(*, x):
             pass
 
         with self.assertRaises(TypeError):


### PR DESCRIPTION
- Validate that the signature of an overridden method `is_compatible` with the signature of the inherited method that it overrides.
- Allow the library to guarantee not only that overridden methods must actually override an inherited method but also that any call to the inherited method can be made on the overridden method.