### PR TITLE
Ignore first parameter for non-static methods

### DIFF
--- a/overrides/overrides.py
+++ b/overrides/overrides.py
@@ -105,7 +105,7 @@ def _validate_method(method, super_class, check_signature):
         and not method.__name__.startswith("__")
         and not isinstance(super_method, property)
     ):
-        ensure_signature_is_compatible(super_method, method, is_method=True)
+        ensure_signature_is_compatible(super_method, method)
 
 
 def _get_base_classes(frame, namespace):

--- a/overrides/overrides.py
+++ b/overrides/overrides.py
@@ -105,7 +105,7 @@ def _validate_method(method, super_class, check_signature):
         and not method.__name__.startswith("__")
         and not isinstance(super_method, property)
     ):
-        ensure_signature_is_compatible(super_method, method)
+        ensure_signature_is_compatible(super_method, method, is_method=True)
 
 
 def _get_base_classes(frame, namespace):

--- a/overrides/signature.py
+++ b/overrides/signature.py
@@ -10,8 +10,7 @@ _WrappedMethod = TypeVar("_WrappedMethod", bound=Union[FunctionType, Callable])
 
 def ensure_signature_is_compatible(
     super_callable: _WrappedMethod,
-    sub_callable: _WrappedMethod,
-    is_method: bool = False,
+    sub_callable: _WrappedMethod
 ) -> None:
     """Ensure that the signature of `sub_callable` is compatible with the signature of `super_callable`.
 
@@ -37,7 +36,7 @@ def ensure_signature_is_compatible(
 
     method_name = sub_callable.__name__
 
-    check_first_parameter = not is_method or isinstance(sub_callable, staticmethod)
+    check_first_parameter = is_bound_sub and is_bound_super
 
     ensure_return_type_compatibility(super_type_hints, sub_type_hints, method_name)
     ensure_all_args_defined_in_sub(
@@ -84,6 +83,7 @@ def ensure_all_args_defined_in_sub(
                     super_param.kind == Parameter.KEYWORD_ONLY
                     and sub_param.kind == Parameter.POSITIONAL_OR_KEYWORD
                 )
+                and (sub_index > 0 or check_first_parameter)
             ):
                 raise TypeError(
                     f"{method_name}: `{name}` is not `{super_param.kind.description}`"

--- a/overrides/signature.py
+++ b/overrides/signature.py
@@ -128,7 +128,9 @@ def is_param_defined_in_sub(
     )
 
 
-def ensure_no_extra_args_in_sub(super_sig, sub_sig, check_first_parameter: bool, method_name: str):
+def ensure_no_extra_args_in_sub(
+    super_sig, sub_sig, check_first_parameter: bool, method_name: str
+):
     super_var_args = any(
         p.kind == Parameter.VAR_POSITIONAL for p in super_sig.parameters.values()
     )

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -123,60 +123,60 @@ class EnforceTests(unittest.TestCase):
                     pass
 
     def test_ensure_compatible_when_compatible(self):
-        def sup(self,a, /, b: str, c: int, *, d, e, **kwargs) -> object:
+        def sup(self, a, /, b: str, c: int, *, d, e, **kwargs) -> object:
             pass
 
-        def sub(self,
-            a, b: object, c, d, f: str = "foo", *args, g: str = "bar", e, **kwargs
+        def sub(
+            self, a, b: object, c, d, f: str = "foo", *args, g: str = "bar", e, **kwargs
         ) -> str:
             pass
 
         ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_type_hints_are_strings(self):
-        def sup(self,x: "str") -> "object":
+        def sup(self, x: "str") -> "object":
             pass
 
-        def sub(self,x: "object") -> "str":
+        def sub(self, x: "object") -> "str":
             pass
 
         ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_return_types_are_incompatible(self):
-        def sup(self,x) -> int:
+        def sup(self, x) -> int:
             pass
 
-        def sub(self,x) -> str:
+        def sub(self, x) -> str:
             pass
 
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_parameter_positions_are_incompatible(self):
-        def sup(self,x, y):
+        def sup(self, x, y):
             pass
 
-        def sub(self,y, x):
+        def sub(self, y, x):
             pass
 
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_parameter_types_are_incompatible(self):
-        def sup(self,x: object):
+        def sup(self, x: object):
             pass
 
-        def sub(self,y: str):
+        def sub(self, y: str):
             pass
 
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_parameter_kinds_are_incompatible(self):
-        def sup(self,x):
+        def sup(self, x):
             pass
 
-        def sub(self,*, x):
+        def sub(self, *, x):
             pass
 
         with self.assertRaises(TypeError):
@@ -307,3 +307,64 @@ class EnforceTests(unittest.TestCase):
         ensure_signature_is_compatible(superb, optional_positional_arg)
         # superb() => optional_kw_only_arg()
         ensure_signature_is_compatible(superb, optional_kw_only_arg)
+
+    def test_signatures_when_self_mismach(self):
+        class A:
+            def foo(self, x: int):
+                pass
+
+        class B:
+            def bar(self, x: int):
+                pass
+
+        class C:
+            def zoo(self, x: str):
+                pass
+
+        ensure_signature_is_compatible(A().foo, B().bar)
+        with self.assertRaises(TypeError):
+            ensure_signature_is_compatible(A().foo, C().zoo)
+
+        ensure_signature_is_compatible(A.foo, B().bar)
+        with self.assertRaises(TypeError):
+            ensure_signature_is_compatible(A.foo, C().zoo)
+
+        ensure_signature_is_compatible(A.foo, B.bar)
+        with self.assertRaises(TypeError):
+            ensure_signature_is_compatible(A.foo, C.zoo)
+
+        ensure_signature_is_compatible(A().foo, B.bar)
+        with self.assertRaises(TypeError):
+            ensure_signature_is_compatible(A().foo, C.zoo)
+
+    def test_signature_with_static_method(self):
+        class A:
+            @staticmethod
+            def foo(x: int):
+                pass
+
+        class B:
+            @staticmethod
+            def bar(x: int):
+                pass
+
+        class C:
+            @staticmethod
+            def zoo(x: str):
+                pass
+
+        ensure_signature_is_compatible(A().foo, B().bar, True)
+        with self.assertRaises(TypeError):
+            ensure_signature_is_compatible(A().foo, C().zoo, True)
+
+        ensure_signature_is_compatible(A.foo, B().bar, True)
+        with self.assertRaises(TypeError):
+            ensure_signature_is_compatible(A.foo, C().zoo, True)
+
+        ensure_signature_is_compatible(A.foo, B.bar, True)
+        with self.assertRaises(TypeError):
+            ensure_signature_is_compatible(A.foo, C.zoo, True)
+
+        ensure_signature_is_compatible(A().foo, B.bar, True)
+        with self.assertRaises(TypeError):
+            ensure_signature_is_compatible(A().foo, C.zoo, True)

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -123,10 +123,10 @@ class EnforceTests(unittest.TestCase):
                     pass
 
     def test_ensure_compatible_when_compatible(self):
-        def sup(a, /, b: str, c: int, *, d, e, **kwargs) -> object:
+        def sup(self,a, /, b: str, c: int, *, d, e, **kwargs) -> object:
             pass
 
-        def sub(
+        def sub(self,
             a, b: object, c, d, f: str = "foo", *args, g: str = "bar", e, **kwargs
         ) -> str:
             pass
@@ -134,89 +134,89 @@ class EnforceTests(unittest.TestCase):
         ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_type_hints_are_strings(self):
-        def sup(x: "str") -> "object":
+        def sup(self,x: "str") -> "object":
             pass
 
-        def sub(x: "object") -> "str":
+        def sub(self,x: "object") -> "str":
             pass
 
         ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_return_types_are_incompatible(self):
-        def sup(x) -> int:
+        def sup(self,x) -> int:
             pass
 
-        def sub(x) -> str:
+        def sub(self,x) -> str:
             pass
 
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_parameter_positions_are_incompatible(self):
-        def sup(x, y):
+        def sup(self,x, y):
             pass
 
-        def sub(y, x):
+        def sub(self,y, x):
             pass
 
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_parameter_types_are_incompatible(self):
-        def sup(x: object):
+        def sup(self,x: object):
             pass
 
-        def sub(y: str):
+        def sub(self,y: str):
             pass
 
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_parameter_kinds_are_incompatible(self):
-        def sup(x):
+        def sup(self,x):
             pass
 
-        def sub(*, x):
+        def sub(self,*, x):
             pass
 
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_parameter_lists_are_incompatible(self):
-        def sup(x):
+        def sup(self, x):
             pass
 
-        def sub(x, y):
+        def sub(self, x, y):
             pass
 
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_missing_arg(self):
-        def sup():
+        def sup(self):
             pass
 
-        def sub(x):
+        def sub(self, x):
             pass
 
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(sup, sub)
 
     def test_ensure_compatible_when_additional_arg(self):
-        def sup(x):
+        def sup(self, x):
             pass
 
-        def sub():
+        def sub(self):
             pass
 
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(sup, sub)
 
     def test_union_compatible(self):
-        def sup(x: int):
+        def sup(self, x: int):
             pass
 
-        def sub(x: Union[int, str]):
+        def sub(self, x: Union[int, str]):
             pass
 
         ensure_signature_is_compatible(sup, sub)
@@ -224,10 +224,10 @@ class EnforceTests(unittest.TestCase):
             ensure_signature_is_compatible(sub, sup)
 
     def test_generic_sub(self):
-        def better_typed_method(x: int, y: Optional[str], z: float = 3.0):
+        def better_typed_method(self, x: int, y: Optional[str], z: float = 3.0):
             pass
 
-        def generic_method(*args, **kwargs):
+        def generic_method(self, *args, **kwargs):
             pass
 
         ensure_signature_is_compatible(better_typed_method, generic_method)
@@ -235,13 +235,13 @@ class EnforceTests(unittest.TestCase):
             ensure_signature_is_compatible(generic_method, better_typed_method)
 
     def test_if_super_has_args_then_sub_must_have(self):
-        def sub1(x=2, y=3, z=4, /):
+        def sub1(self, x=2, y=3, z=4, /):
             pass
 
-        def subbest(x=1, /, *burgs):
+        def subbest(self, x=1, /, *burgs):
             pass
 
-        def supah(*args):
+        def supah(self, *args):
             pass
 
         # supah() => subbest()
@@ -267,13 +267,13 @@ class EnforceTests(unittest.TestCase):
             ensure_signature_is_compatible(subbest, sub1)
 
     def test_if_super_has_kwargs_then_sub_must_have(self):
-        def sub1(*, x=3, y=3, z=4):
+        def sub1(self, *, x=3, y=3, z=4):
             pass
 
-        def sus(*, x=3, **kwargs):
+        def sus(self, *, x=3, **kwargs):
             pass
 
-        def superb(**kwargs):
+        def superb(self, **kwargs):
             pass
 
         # superb() => sus()
@@ -289,16 +289,16 @@ class EnforceTests(unittest.TestCase):
             ensure_signature_is_compatible(sus, sub1)
 
     def test_allowed_extra_args_in_overrider(self):
-        def superb():
+        def superb(self):
             pass
 
-        def optional_arg(arg=1):
+        def optional_arg(self, arg=1):
             pass
 
-        def optional_positional_arg(arg2=2, /):
+        def optional_positional_arg(self, arg2=2, /):
             pass
 
-        def optional_kw_only_arg(*, arg3=3):
+        def optional_kw_only_arg(self, *, arg3=3):
             pass
 
         # superb() => optional_arg()

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -314,7 +314,7 @@ class EnforceTests(unittest.TestCase):
                 pass
 
         class B:
-            def bar(self, x: int):
+            def bar(me, x: int):
                 pass
 
         class C:

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -21,6 +21,11 @@ class SubSubClassOfGeneric(SubClassOfGeneric["SubSubClassOfGeneric"]):
 
 
 class SuperClass(object):
+
+    @staticmethod
+    def this_is_static(x, y, z):
+        pass
+
     def some_method(self):
         """Super Class Docs"""
         return "super"
@@ -61,6 +66,13 @@ class CheckAtRuntime(SuperClass):
         pass
 
 
+class StaticMethodOverridePass(SuperClass):
+    @staticmethod
+    @overrides
+    def this_is_static(x, y, z, *args):
+        pass
+
+
 class OverridesTests(unittest.TestCase):
     def test_overrides_passes_for_same_package_superclass(self):
         sub = SubClass()
@@ -83,6 +95,19 @@ class OverridesTests(unittest.TestCase):
             class ShouldFail(SuperClass):
                 @overrides
                 def somo_method(self):
+                    pass
+
+            raise RuntimeError("Should not go here")
+        except TypeError:
+            pass
+
+    def test_static_method(self):
+        try:
+
+            class StaticMethodOverrideFail(SuperClass):
+                @staticmethod
+                @overrides
+                def this_is_static(k, y, z):
                     pass
 
             raise RuntimeError("Should not go here")

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -21,7 +21,6 @@ class SubSubClassOfGeneric(SubClassOfGeneric["SubSubClassOfGeneric"]):
 
 
 class SuperClass(object):
-
     @staticmethod
     def this_is_static(x, y, z):
         pass

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -62,6 +62,17 @@ class SelfTypedOverride(SuperbClass):
         return None
 
 
+class A:
+    def foo(self: int):
+        pass
+
+
+class B(A):
+    @overrides
+    def foo(self: str):
+        pass
+
+
 def test_that_this_file_is_ok():
     pass
 

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -16,7 +16,7 @@ class SuperbClass:
 
     def normal_method(self, x: int, y: str = "hello", *args, **kwargs) -> bool:
         return x == 1 or y == "bar" or len(args) == 3 or "zoo" in kwargs
-    
+
     def self_typed_method(self: "SuperbClass") -> "SuperbClass":
         return self
 

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Type, Union
 
 from overrides import overrides
 
@@ -16,6 +16,13 @@ class SuperbClass:
 
     def normal_method(self, x: int, y: str = "hello", *args, **kwargs) -> bool:
         return x == 1 or y == "bar" or len(args) == 3 or "zoo" in kwargs
+    
+    def self_typed_method(self: "SuperbClass") -> "SuperbClass":
+        return self
+
+    @classmethod
+    def self_typed_class_method(cls: "Type[SuperbClass]") -> None:
+        return None
 
 
 class ClassMethodOverrider(SuperbClass):
@@ -44,5 +51,21 @@ class OverridesWithSignatureIgnore(SuperbClass):
         return x % 2 == 1
 
 
+class SelfTypedOverride(SuperbClass):
+    @overrides(check_at_runtime=True)
+    def self_typed_method(self: "SelfTypedOverride") -> "SelfTypedOverride":
+        return self
+
+    @classmethod
+    @overrides(check_at_runtime=True)
+    def self_typed_class_method(cls: "Type[SelfTypedOverride]") -> None:
+        return None
+
+
 def test_that_this_file_is_ok():
     pass
+
+
+def test_self_typed_overrides():
+    SelfTypedOverride().self_typed_method()
+    SelfTypedOverride().self_typed_class_method()


### PR DESCRIPTION
- Don't type check `self` or `cls` parameters.