### PR TITLE
Fix signature check for nested unbound generic types

### DIFF
--- a/overrides/final.py
+++ b/overrides/final.py
@@ -41,8 +41,8 @@ def final(method: _WrappedMethod) -> _WrappedMethod:
         def method(self): #causes an error
             return 1
 
-    :raises  AssertionError if there exists a match in sub classes for the method name
-    :return  method
+    :raises AssertionError: if there exists a match in sub classes for the method name
+    :return: method
     """
     setattr(method, "__finalized__", True)
     return method

--- a/overrides/overrides.py
+++ b/overrides/overrides.py
@@ -59,8 +59,8 @@ def overrides(
 
     :param check_signature: Whether or not to check the signature of the overridden method.
     :param check_at_runtime: Whether or not to check the overridden method at runtime.
-    :raises  AssertionError if no match in super classes for the method name
-    :return  method with possibly added (if the method doesn't have one)
+    :raises AssertionError: if no match in super classes for the method name
+    :return: method with possibly added (if the method doesn't have one)
         docstring from super class
     """
     if method:

--- a/tests/test_enforce.py
+++ b/tests/test_enforce.py
@@ -1,7 +1,7 @@
 import unittest
-from typing import Union, Optional, TypeVar
+from typing import Optional, TypeVar, Union
 
-from overrides import overrides, final, EnforceOverrides
+from overrides import EnforceOverrides, final, overrides
 from overrides.signature import ensure_signature_is_compatible
 
 
@@ -38,11 +38,11 @@ class EnforceTests(unittest.TestCase):
 
             @overrides
             def nonfinal1(self, param: int) -> str:
-                return 2
+                return "2"
 
         sc = Subclazz()
         self.assertEqual(sc.finality(), "final")
-        self.assertEqual(sc.nonfinal1(1), 2)
+        self.assertEqual(sc.nonfinal1(1), "2")
         self.assertEqual(sc.nonfinal2(), "super2")
         self.assertEqual(sc.classVariableIsOk, "OK!")
 
@@ -393,6 +393,32 @@ class EnforceTests(unittest.TestCase):
             pass
 
         def return_typed(t) -> int:
+            pass
+
+        ensure_signature_is_compatible(typevarred, untyped, True)
+        ensure_signature_is_compatible(typevarred, typed, True)
+        ensure_signature_is_compatible(untyped, typevarred, True)
+        ensure_signature_is_compatible(typed, typevarred, True)
+        ensure_signature_is_compatible(untyped, return_typed, True)
+        with self.assertRaises(TypeError):
+            ensure_signature_is_compatible(untyped, typed, True)
+        with self.assertRaises(TypeError):
+            ensure_signature_is_compatible(typed, untyped, True)
+
+    def test_nested_typevar_in_signature(self):
+        T = TypeVar("T")
+        K = TypeVar("K")
+
+        def typevarred(t: Optional[T]) -> Optional[K]:
+            pass
+
+        def typed(t: Optional[str]) -> Optional[int]:
+            pass
+
+        def untyped(t):
+            pass
+
+        def return_typed(t) -> Optional[int]:
             pass
 
         ensure_signature_is_compatible(typevarred, untyped, True)


### PR DESCRIPTION
Hi @mkorpela!

Two changes:
- Adds a test that fails with `overrides==5.0.0`. (`TypeVar` when nested inside other generic types)
    - The original error message is: `TypeError: issubclass() arg 2 must be a class or tuple of classes`
- Tweaks the signature checks to check recursively for unbound `TypeVar` types.