### PR TITLE
Correct overloads for `@overrides` decorator

### DIFF
--- a/overrides/overrides.py
+++ b/overrides/overrides.py
@@ -19,7 +19,7 @@ import functools
 import inspect
 import sys
 from types import FunctionType
-from typing import Any, Callable, List, Tuple, TypeVar, Union
+from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union, overload
 
 __VERSION__ = "5.0.1"
 
@@ -28,8 +28,28 @@ from overrides.signature import ensure_signature_is_compatible
 _WrappedMethod = TypeVar("_WrappedMethod", bound=Union[FunctionType, Callable])
 
 
+@overload
 def overrides(
-    method: _WrappedMethod = None,
+    method: None = None,
+    *,
+    check_signature: bool = True,
+    check_at_runtime: bool = False,
+) -> Callable[[_WrappedMethod], _WrappedMethod]:
+    ...
+
+
+@overload
+def overrides(
+    method: _WrappedMethod,
+    *,
+    check_signature: bool = True,
+    check_at_runtime: bool = False,
+) -> _WrappedMethod:
+    ...
+
+
+def overrides(
+    method: Optional[_WrappedMethod] = None,
     *,
     check_signature: bool = True,
     check_at_runtime: bool = False,
@@ -63,7 +83,7 @@ def overrides(
     :return: method with possibly added (if the method doesn't have one)
         docstring from super class
     """
-    if method:
+    if method is not None:
         return _overrides(method, check_signature, check_at_runtime)
     else:
         return functools.partial(

--- a/overrides/overrides.py
+++ b/overrides/overrides.py
@@ -26,6 +26,7 @@ __VERSION__ = "5.0.1"
 from overrides.signature import ensure_signature_is_compatible
 
 _WrappedMethod = TypeVar("_WrappedMethod", bound=Union[FunctionType, Callable])
+_DecoratorMethod = Callable[[_WrappedMethod], _WrappedMethod]
 
 
 @overload
@@ -34,7 +35,7 @@ def overrides(
     *,
     check_signature: bool = True,
     check_at_runtime: bool = False,
-) -> Callable[[_WrappedMethod], _WrappedMethod]:
+) -> _DecoratorMethod:
     ...
 
 
@@ -53,7 +54,7 @@ def overrides(
     *,
     check_signature: bool = True,
     check_at_runtime: bool = False,
-) -> Any:
+) -> Union[_DecoratorMethod, _WrappedMethod]:
     """Decorator to indicate that the decorated method overrides a method in
     superclass.
     The decorator code is executed while loading class. Using this method


### PR DESCRIPTION
When `@overrides` is typed with `Any`, static analysis breaks for all decorated functions. (this is bad!)