### PR TITLE
Allow typed overrides of methods with untyped arguments

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,3 +7,4 @@ def pytest_ignore_collect(path: py.path.local, config: "Config") -> Optional[boo
     if sys.version_info[0] == 3 and sys.version_info[1] < 8:
         if str(path).endswith("__py38.py"):
             return True
+    return None

--- a/overrides/signature.py
+++ b/overrides/signature.py
@@ -209,7 +209,7 @@ def ensure_all_positional_args_defined_in_sub(
             raise TypeError(
                 f"{method_name}: `{sub_param.name}` is not `{super_param.kind.description}` and is `{sub_param.kind.description}`"
             )
-        elif not _issubtype(
+        elif super_param.name in super_type_hints and not _issubtype(
             super_type_hints.get(super_param.name, None),
             sub_type_hints.get(sub_param.name, None),
         ):

--- a/tests/test_enforce__py38.py
+++ b/tests/test_enforce__py38.py
@@ -400,8 +400,7 @@ class EnforceTests(unittest.TestCase):
         ensure_signature_is_compatible(untyped, typevarred, True)
         ensure_signature_is_compatible(typed, typevarred, True)
         ensure_signature_is_compatible(untyped, return_typed, True)
-        with self.assertRaises(TypeError):
-            ensure_signature_is_compatible(untyped, typed, True)
+        ensure_signature_is_compatible(untyped, typed, True)
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(typed, untyped, True)
 
@@ -426,7 +425,6 @@ class EnforceTests(unittest.TestCase):
         ensure_signature_is_compatible(untyped, typevarred, True)
         ensure_signature_is_compatible(typed, typevarred, True)
         ensure_signature_is_compatible(untyped, return_typed, True)
-        with self.assertRaises(TypeError):
-            ensure_signature_is_compatible(untyped, typed, True)
+        ensure_signature_is_compatible(untyped, typed, True)
         with self.assertRaises(TypeError):
             ensure_signature_is_compatible(typed, untyped, True)

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -1,9 +1,8 @@
 import unittest
-from overrides import overrides
-import test_somepackage
-
-
 from typing import Generic, TypeVar
+
+import test_somepackage
+from overrides import overrides
 
 TObject = TypeVar("TObject", bound="Foo")
 

--- a/tests/test_signatures.py
+++ b/tests/test_signatures.py
@@ -1,4 +1,4 @@
-from typing import Type, Union
+from typing import Any, Type, Union
 
 from overrides import overrides
 
@@ -79,6 +79,17 @@ class A:
 class B(A):
     @overrides
     def foo(self: str):
+        pass
+
+
+class UntypedBaseClass:
+    def do_something(self, arg1, arg2=None):
+        pass
+
+
+class TypedSubclass(UntypedBaseClass):
+    @overrides
+    def do_something(self, arg1: str, arg2: Any = None) -> Any:
         pass
 
 


### PR DESCRIPTION
Main change is to only check superclass type hints that are actually present; same issue as in #77.

@mkorpela feel free to close if you disagree with this behavior!