### PR TITLE
Support for overriding inner classes

### DIFF
--- a/overrides/overrides.py
+++ b/overrides/overrides.py
@@ -100,7 +100,10 @@ def _overrides(
     check_at_runtime: bool,
 ) -> _WrappedMethod:
     setattr(method, "__override__", True)
-    for super_class in _get_base_classes(sys._getframe(3), method.__globals__):
+    global_vars = getattr(method, "__globals__", None)
+    if global_vars is None:
+        global_vars = vars(sys.modules[method.__module__])
+    for super_class in _get_base_classes(sys._getframe(3), global_vars):
         if hasattr(super_class, method.__name__):
             if check_at_runtime:
 

--- a/overrides/overrides.py
+++ b/overrides/overrides.py
@@ -19,13 +19,13 @@ import functools
 import inspect
 import sys
 from types import FunctionType
-from typing import Any, Callable, List, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import Any, Callable, List, Optional, Tuple, TypeVar, Union, overload
 
 __VERSION__ = "6.2.0"
 
 from overrides.signature import ensure_signature_is_compatible
 
-_WrappedMethod = TypeVar("_WrappedMethod", bound=Union[FunctionType, Callable, Type])
+_WrappedMethod = TypeVar("_WrappedMethod", bound=Union[FunctionType, Callable])
 _DecoratorMethod = Callable[[_WrappedMethod], _WrappedMethod]
 
 
@@ -52,7 +52,6 @@ def overrides(
 def overrides(
     method: Optional[_WrappedMethod] = None,
     *,
-    super_class: Optional[Type] = None,
     check_signature: bool = True,
     check_at_runtime: bool = False,
 ) -> Union[_DecoratorMethod, _WrappedMethod]:
@@ -86,11 +85,10 @@ def overrides(
         docstring from super class
     """
     if method is not None:
-        return _overrides(method, super_class, check_signature, check_at_runtime)
+        return _overrides(method, check_signature, check_at_runtime)
     else:
         return functools.partial(
             overrides,
-            super_class=super_class,
             check_signature=check_signature,
             check_at_runtime=check_at_runtime,
         )
@@ -98,32 +96,24 @@ def overrides(
 
 def _overrides(
     method: _WrappedMethod,
-    super_class: Optional[Type],
     check_signature: bool,
     check_at_runtime: bool,
 ) -> _WrappedMethod:
     setattr(method, "__override__", True)
-    if super_class is None:
-        globals = getattr(method, "__globals__", None)
-        if globals is None:
-            raise TypeError(f"{method.__qualname__}: Unable to deduce superclass, use overrides(super_class=...)")
-        for candidate_super_class in _get_base_classes(sys._getframe(3), globals):
-            if hasattr(candidate_super_class, method.__name__):
-                super_class = candidate_super_class
-                break
-    if super_class is None:
-        raise TypeError(f"{method.__qualname__}: No super class method found, use overrides(super_class=...)")
-    if check_at_runtime:
+    for super_class in _get_base_classes(sys._getframe(3), method.__globals__):
+        if hasattr(super_class, method.__name__):
+            if check_at_runtime:
 
-        @functools.wraps(method)
-        def wrapper(*args, **kwargs):
-            _validate_method(method, super_class, check_signature)
-            return method(*args, **kwargs)
+                @functools.wraps(method)
+                def wrapper(*args, **kwargs):
+                    _validate_method(method, super_class, check_signature)
+                    return method(*args, **kwargs)
 
-        return wrapper  # type: ignore
-    else:
-        _validate_method(method, super_class, check_signature)
-        return method
+                return wrapper  # type: ignore
+            else:
+                _validate_method(method, super_class, check_signature)
+                return method
+    raise TypeError(f"{method.__qualname__}: No super class method found")
 
 
 def _validate_method(method, super_class, check_signature):
@@ -140,7 +130,6 @@ def _validate_method(method, super_class, check_signature):
     if (
         check_signature
         and not method.__name__.startswith("__")
-        and not isinstance(super_method, type)
         and not isinstance(super_method, property)
     ):
         ensure_signature_is_compatible(super_method, method, is_static)

--- a/tests/test_final.py
+++ b/tests/test_final.py
@@ -70,7 +70,7 @@ class FinalTests(unittest.TestCase):
         try:
 
             class SubClassFail(SuperClass):
-                @overrides(super_class=SuperClass)
+                @overrides
                 class SomeFinalClass:
                     pass
 

--- a/tests/test_final.py
+++ b/tests/test_final.py
@@ -12,6 +12,9 @@ class SuperClass(object):
     def some_finalized_method(self):
         return "super_final"
 
+    @final
+    class SomeFinalClass:
+        pass
 
 class SubClass(SuperClass):
     @overrides
@@ -57,6 +60,18 @@ class FinalTests(unittest.TestCase):
 
                 @overrides
                 def some_finalized_method(self):
+                    pass
+
+            raise RuntimeError("Should not go here")
+        except TypeError:
+            pass
+
+    def test_final_fails_inner_class(self):
+        try:
+
+            class SubClassFail(SuperClass):
+                @overrides(super_class=SuperClass)
+                class SomeFinalClass:
                     pass
 
             raise RuntimeError("Should not go here")

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -76,7 +76,7 @@ class StaticMethodOverridePass(SuperClass):
 
 
 class InnerClassOverride(SuperClass):
-    @overrides(super_class=SuperClass)
+    @overrides
     class SomeClass:
         def check(self):
             return 1

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -28,6 +28,10 @@ class SuperClass(object):
         """Super Class Docs"""
         return "super"
 
+    class SomeClass:
+        """Super Inner Class Docs"""
+        def check(self):
+            return 0
 
 class SubClass(SuperClass):
     @overrides
@@ -71,11 +75,24 @@ class StaticMethodOverridePass(SuperClass):
         pass
 
 
+class InnerClassOverride(SuperClass):
+    @overrides(super_class=SuperClass)
+    class SomeClass:
+        def check(self):
+            return 1
+
 class OverridesTests(unittest.TestCase):
     def test_overrides_passes_for_same_package_superclass(self):
         sub = SubClass()
         self.assertEqual(sub.some_method(), "sub")
         self.assertEqual(sub.some_method.__doc__, "Super Class Docs")
+
+    def test_override_inner_class(self):
+        sup = SuperClass.SomeClass()
+        sub = InnerClassOverride.SomeClass()
+        self.assertEqual(sup.check(), 0)
+        self.assertEqual(sub.check(), 1)
+        self.assertEqual(sup.__doc__, sub.__doc__)
 
     def test_overrides_does_not_override_method_doc(self):
         sub = Subber()


### PR DESCRIPTION
In some patterns, overriding inner classes is desireable. The inner
class does not have `__globals__`, so explicitly specifying the superclass is
necessary (I think). Example:

```
class Base:
    class Params:
        pass

class Derived(Base, EnforceOverrides):
    @overrides(super_class=Base)
    class Params:
        pass
```