### PR TITLE
If overriden method has no __module__ assume _is_same_module is False

### DIFF
--- a/overrides/signature.py
+++ b/overrides/signature.py
@@ -85,7 +85,12 @@ def ensure_signature_is_compatible(
     """
     super_callable = _unbound_func(super_callable)
     sub_callable = _unbound_func(sub_callable)
-    super_sig = inspect.signature(super_callable)
+
+    try:
+        super_sig = inspect.signature(super_callable)
+    except ValueError:
+        return
+
     super_type_hints = _get_type_hints(super_callable)
     sub_sig = inspect.signature(sub_callable)
     sub_type_hints = _get_type_hints(sub_callable)

--- a/overrides/signature.py
+++ b/overrides/signature.py
@@ -54,7 +54,11 @@ def _get_type_hints(callable) -> Optional[Dict]:
 
 def _is_same_module(callable1: _WrappedMethod, callable2: _WrappedMethod2) -> bool:
     mod1 = callable1.__module__.split(".")[0]
-    mod2 = callable2.__module__.split(".")[0]
+    try:
+        mod2 = callable2.__module__
+    except AttributeError:
+        return False
+    mod2 = mod2.split(".")[0]
     return mod1 == mod2
 
 

--- a/tests/test_overrides.py
+++ b/tests/test_overrides.py
@@ -57,6 +57,10 @@ class SubclassOfInt(int):
     def __str__(self):
         return "subclass of int"
 
+    @overrides
+    def bit_length(self):
+        pass
+
 
 class CheckAtRuntime(SuperClass):
     @overrides(check_at_runtime=True)


### PR DESCRIPTION
First off, thank you for this awesome package!

This PR, intends to resolve a minor bug I describe below. I originally encountered the issue while attempting to use overrides with a class from PySide6 (Qt framework package).

But luckily I was able to reproduce the issue more simply using a builtin:
```python
>>> from overrides import overrides
>>> class Foo(int):
...     @overrides
...     def bit_length(self):
...         pass
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 3, in Foo
  File "/Users/tjsmart/Work/python/overrides/overrides/overrides.py", line 88, in overrides
    return _overrides(method, check_signature, check_at_runtime)
  File "/Users/tjsmart/Work/python/overrides/overrides/overrides.py", line 114, in _overrides
    _validate_method(method, super_class, check_signature)
  File "/Users/tjsmart/Work/python/overrides/overrides/overrides.py", line 135, in _validate_method
    ensure_signature_is_compatible(super_method, method, is_static)
  File "/Users/tjsmart/Work/python/overrides/overrides/signature.py", line 90, in ensure_signature_is_compatible
    same_main_module = _is_same_module(sub_callable, super_callable)
  File "/Users/tjsmart/Work/python/overrides/overrides/signature.py", line 57, in _is_same_module
    mod2 = callable2.__module__.split(".")[0]
AttributeError: 'method_descriptor' object has no attribute '__module__'
```

For some reason, unknown to me, not all methods in python have a __module__. It sort of makes sense for a builtin method like `int.bit_length`. But I don't know why it happens for other packages (such as PySide6).

I think the solution I proposed is self explanatory but please let me know if I should include more details.


FYI, this is my first contribution to an open source project. Please, let me know if I missed any checks!