### PR TITLE
Fix _is_same_module() on PyPy

### DIFF
--- a/overrides/signature.py
+++ b/overrides/signature.py
@@ -54,9 +54,10 @@ def _get_type_hints(callable) -> Optional[Dict]:
 
 def _is_same_module(callable1: _WrappedMethod, callable2: _WrappedMethod2) -> bool:
     mod1 = callable1.__module__.split(".")[0]
-    try:
-        mod2 = callable2.__module__
-    except AttributeError:
+    # "__module__" attribute may be missing in CPython or it can be None
+    # in PyPy: https://github.com/mkorpela/overrides/issues/118
+    mod2 = getattr(callable2, "__module__", None)
+    if mod2 is None:
         return False
     mod2 = mod2.split(".")[0]
     return mod1 == mod2


### PR DESCRIPTION
Fix `_is_same_module()` to account for `__module__` attribute possibly being `None`, as it currently is in PyPy, rather than non-present, as it is in CPython.

Fixes #118