### PR TITLE
fix: `AttributeError` by checking method types in custom metaclasses

### DIFF
--- a/overrides/__init__.py
+++ b/overrides/__init__.py
@@ -1,4 +1,4 @@
-from overrides.enforce import EnforceOverrides
+from overrides.enforce import EnforceOverrides, EnforceOverridesMeta
 import sys
 
 if sys.version_info < (3, 11):
@@ -14,4 +14,5 @@ __all__ = [
     "overrides",
     "final",
     "EnforceOverrides",
+    "EnforceOverridesMeta",
 ]

--- a/overrides/enforce.py
+++ b/overrides/enforce.py
@@ -1,3 +1,4 @@
+import types
 from abc import ABCMeta
 
 
@@ -7,7 +8,9 @@ class EnforceOverridesMeta(ABCMeta):
         for method in dir(mcls):
             if not method.startswith("__") and method != "mro":
                 value = getattr(mcls, method)
-                if not isinstance(value, (bool, str, int, float, tuple, list, dict)):
+                if not isinstance(
+                    value, (bool, str, int, float, tuple, list, dict, types.MethodType)
+                ):
                     setattr(getattr(mcls, method), "__ignored__", True)
 
         cls = super().__new__(mcls, name, bases, namespace, **kwargs)

--- a/tests/test_inheritance_with_custom_metaclass.py
+++ b/tests/test_inheritance_with_custom_metaclass.py
@@ -1,0 +1,26 @@
+from overrides import EnforceOverrides
+from overrides.enforce import EnforceOverridesMeta
+import unittest
+
+
+class CustomMetaClass(EnforceOverridesMeta):
+    def __new__(metacls, classname, bases, classdict, **kwargs):
+        return super().__new__(metacls, classname, bases, classdict, **kwargs)
+
+    @classmethod
+    def foo(cls):
+        pass
+
+    def bar(self):
+        pass
+
+
+class SuperbClass(EnforceOverrides, metaclass=CustomMetaClass):
+    pass
+
+
+class InheritanceWithCustomMetaclass(unittest.TestCase):
+    def test_inheritance_with_EnforceOverrides_and_custom_metaclass(self):
+        sc = SuperbClass()
+        self.assertIsInstance(sc, SuperbClass)
+        self.assertTrue(issubclass(SuperbClass, EnforceOverrides))


### PR DESCRIPTION
Thanks for the great package!

I had a case where I tried to inherit from `EnforceOverrides` when using a custom metaclass, inheriting from `abc.ABCMeta` at the same time. As this was not possible due to Python's requirement that the metaclass of a subclass must be a subclass of the metaclass of all its bases, I ended up importing `EnforceOverridesMeta` directly from `overrides.enforce` and using it as the base of my custom metaclass.

Here is an example when using the `EnforceOverridesMeta` on a custom metaclass:
```python
from overrides.enforce import EnforceOverridesMeta, EnforceOverrides

class MyMeta(EnforceOverridesMeta):
    def foo(self):
        pass

class MyClass(EnforceOverrides, metaclass=MyMeta):
    def bar(self):
        pass
```

Attempting to set the `__ignored__` attribute on `foo` raises an `AttributeError` because the method objects, particulary those bound to a class, do not support attribute assignments.

I think it would be great if we could export `EnforceOverridesMeta` from the package directly and use it as the base of our own custom metaclasses.

This PR exports the `EnforceOverridesMeta` metaclass from the package and implements a check for the type of method objects in the metaclass to differentiate between function objects and other callable types that do not support attribute assignments. By identifying function types by `types.FunctionType`, this fix avoids the `AttributeError`.