### PR TITLE
Remove EOL versions. Add freethreaded and prereleases. Update setup-python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.13t', '3.14', '3.14t']
 
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - name: Install requirements
         run: |
          pip install -U pip


### PR DESCRIPTION
Python version 3.7 and 3.8 are now EOL, and can no longer be guaranteed to be available on GitHub-hosted runners using `ubuntu-latest`. More info here: https://github.com/actions/setup-python/issues/962#issuecomment-2414418045

As a result, recent pull requests against this repo will consistently fail. To remedy this, the version list in the matrix should be updated. In this PR, I've updated the versions to not only drop EOL versions, but also to include new versions, freethreaded versions, and prereleases as well. **Note: I expect CI to fail for both python 3.14 and 3.14t. `ByteString` was removed from the `typing` stdlib. This issue is independently addressed by #133.** Once either this PR or PR #133 is merged, the other should be able to trigger a successful CI run

Thanks so much for this package! Let me know if you have any questions or concerns about this PR.
