### PR TITLE
Fix support for pytest 9.0

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,10 @@
 import sys
+from pathlib import Path
 from typing import Optional
 
-import py
 
-
-def pytest_ignore_collect(path: py.path.local, config: "Config") -> Optional[bool]:
+def pytest_ignore_collect(collection_path: Path) -> Optional[bool]:
     if sys.version_info[0] == 3 and sys.version_info[1] < 8:
-        if str(path).endswith("__py38.py"):
+        if str(collection_path.name).endswith("__py38.py"):
             return True
     return None


### PR DESCRIPTION
The pytest_ignore_collect function has deprecated the path argument in 7.0 becaues it uses the deprecated py library.

Instead it provides a collection_path parameter that uses a pathlib Path object.

[1] https://docs.pytest.org/en/7.1.x/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path